### PR TITLE
README.md: markdown-ify code blocks, links & lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,11 @@ ABOUT:
 OMAPCONF is a Linux user-space standalone application designed to provide a
 quick'n easy way to diagnose (monitor/debug/audit...) TI OMAP configuration/status
 dynamically at runtime, in any situation:
-	- Any Linux distribution (Ubuntu, ...)
-	- Any Android release (Froyo, GingerBread, HoneyComb,
-	Ice-Cream Sandwich, Jelly Bean, ...)
-	- TI official platforms (blaze, panda, ...),
-	- Custom OMAP platforms, etc.
-	- With no single kernel recompilation needed
+ * Any Linux distribution (Ubuntu, ...)
+ * Any Android release (Froyo, GingerBread, HoneyComb, Ice-Cream Sandwich, Jelly Bean, ...)
+ * TI official platforms (blaze, panda, ...),
+ * Custom OMAP platforms, etc.
+ * With no single kernel recompilation needed
 
 OMAPCONF leverages "/dev/mem" special device to directly access complete
 TI OMAP memory space (registers, ...).
@@ -41,13 +40,15 @@ Build instructions (Ubuntu):
 
 OMAPCONF is available as a Ubuntu package.
 To proceed with package installation type the following:
+
 	# sudo apt-get install tiomapconf
 
 Once package is installed, you can check which omapconf version you are using:
+
 	# dpkg -l tiomapconf
 
 Package is available via TI OMAP4 Ubuntu PPA.
-See http://www.omappedia.org/wiki/PandaBoard_Ubuntu_PPA for further instructions.
+See [the OMAPpedia page](http://www.omappedia.org/wiki/PandaBoard_Ubuntu_PPA "Your mouse is hovering over this link") for further instructions.
 
 
 
@@ -59,18 +60,20 @@ To only build the output binary file:
 NB: CROSS_COMPILE variable must be set to point to the correct compiler.
 
 To build and install ompaconf:
+
 	# make CROSS_COMPILE=arm-none-linux-gnueabi- DESTDIR=YOUR_DIR install
 
 YOUR_DIR is a destination directory where omapconf output binary file will be
 copied (e.g. ubuntu/android filesystem)
 
-That’s it!
+That's it!
 
 
 
 Build instructions and installation via ADB (Android):
 ------------------------------------------------------
 Make sure your Android device is connected to host via ADB:
+
 	# adb kill-server
 	# adb devices
 	* daemon not running. starting it now *
@@ -80,7 +83,8 @@ Make sure your Android device is connected to host via ADB:
 	# adb root
 
 To build and install ompaconf for Android via ADB:
-# make CROSS_COMPILE=arm-none-linux-gnueabi- install_android
+
+	# make CROSS_COMPILE=arm-none-linux-gnueabi- install_android
 
 OMAPCONF binary will be copied to /data directory (known writable directory)
 on your Android device. You may get it copied to a different directory by
@@ -94,5 +98,4 @@ Help:
 Type "./omapconf --help" to get complete list of available commands and options.
 Note that in case of incorrect command/option, help will also be displayed.
 
-A dedicated wiki page is available here:
-	https://github.com/omapconf/omapconf/wiki
+A dedicated wiki page is available [here](https://github.com/omapconf/omapconf/wiki "Github Wiki").


### PR DESCRIPTION
For markdown to treat indented blocks of text as code snippets it is
necessary to separate the code snippets from regular text with a
newline.

Likewise lists must use the format "^ \* $text" to create bullet points
for list items.

This patch properly indents text blocks and bullet points to existing
text and converts plainly printed URLs into hyperlinks with alt-text.

Signed-off-by: Mike Turquette mturquette@linaro.org
