### PR TITLE
Makefile: allow to build tags and cscope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ builddate.c
 Module.symvers
 Module.markers
 modules.order
+cscope.out
+tags

--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,9 @@ I2COBJECTS=	$(I2CSOURCES:.c=.o)
 
 
 
+ALLSOURCES=	$(SOURCES) $(OMAPSOURCES) $(OMAP4SOURCES) $(OMAP5SOURCES)\
+		$(LINUXSOURCES) $(PMICSOURCES) $(AUDIOICSOURCES) $(I2CSOURCES)
+
 
 ALLOBJECTS=	$(OBJECTS) $(OMAPOBJECTS) $(OMAP4OBJECTS) $(OMAP5OBJECTS)\
 		$(LINUXOBJECTS) $(PMICOBJECTS) $(AUDIOICOBJECTS) $(I2COBJECTS)
@@ -281,7 +284,7 @@ ALLOBJECTS=	$(OBJECTS) $(OMAPOBJECTS) $(OMAP4OBJECTS) $(OMAP5OBJECTS)\
 EXECUTABLE=	omapconf
 
 
-
+.PHONY:	tags cscope
 
 all: 		$(EXECUTABLE)
 
@@ -319,6 +322,15 @@ install_android: $(EXECUTABLE)
 		adb push omapconf /data/
 
 
+tags: $(ALLSOURCES)
+	ctags $(shell $(CC) $(MYCFLAGS) -MM -MG $(ALLSOURCES) |\
+			sed -e "s/^.*\.o://g"|tr -d '\\')
+
+
+
+cscope: $(ALLSOURCES)
+	cscope -b $(shell $(CC) $(MYCFLAGS) -MM -MG $(ALLSOURCES) |\
+			sed -e "s/^.*\.o://g"|tr -d '\\')
 
 
 clean:
@@ -331,3 +343,4 @@ clean:
 		rm -f $(PMICOBJECTS)
 		rm -f $(AUDIOICOBJECTS)
 		rm -f $(I2COBJECTS)
+		rm -f tags cscope.out


### PR DESCRIPTION
It is handy to have cscope and tags built from the sources to
account for any change in source without having to run special
scripts
So, add option to 'make tags' and 'make cscope' to generate
the references.

While at it, ignore these generated files from git tracking.

Note: we use -MM -MG options of gcc for this to work to ensure that
we can use the header dependency even for files that have not been
committed to git repository

[j-zheng@ti.com: update to keep in sync with latest code]
Signed-off-by: Jin Zheng j-zheng@ti.com
Signed-off-by: Nishanth Menon nm@ti.com
