### PR TITLE
[DRA7xx] Add ability to decode the IPU AMMUs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,8 @@ OMAPSOURCES=\
 		arch/arm/mach-omap/common/statcoll/sci_swcapture.c\
 		arch/arm/mach-omap/common/statcoll/sci.c\
 		arch/arm/mach-omap/common/statcoll/cToolsHelper.c\
-		arch/arm/mach-omap/common/timestamp_32k.c
+		arch/arm/mach-omap/common/timestamp_32k.c\
+		arch/arm/mach-omap/common/ammu.c
 
 OMAPOBJECTS=	$(OMAPSOURCES:.c=.o)
 
@@ -261,7 +262,8 @@ DRA7SOURCES=\
 		arch/arm/mach-omap/dra7/audit_dra7xx.c\
 		arch/arm/mach-omap/dra7/lib_dra7xx.c\
 		arch/arm/mach-omap/dra7/mcasp_dra7xx.c\
-		arch/arm/mach-omap/dra7/main_dra7xx.c
+		arch/arm/mach-omap/dra7/main_dra7xx.c\
+		arch/arm/mach-omap/dra7/ammu_dra7xx.c
 
 DRA7OBJECTS=	$(DRA7SOURCES:.c=.o)
 

--- a/arch/arm/mach-omap/common/ammu.c
+++ b/arch/arm/mach-omap/common/ammu.c
@@ -1,0 +1,417 @@
+/*
+ *
+ * @Component                   OMAPCONF
+ * @Filename                    ammu.c
+ * @Description                 Functions Related to Parsing AMMU
+ * @Author                      Brad Griffis (bgriffis@ti.com)
+ * @Date                        2017
+ * @Copyright                   Texas Instruments Incorporated
+ *
+ *
+ * Copyright (C) 2017 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <stdio.h>
+#include <mem.h>
+#include <lib.h>
+
+/* ------------------------------------------------------------------------*//**
+ * @FUNCTION            ammu_decode_large_page
+ * @BRIEF               decodes the parameters for a large page from the ammu
+ * @RETURNS             0=success, non-zero error
+ * @param[in]           p_base_addr: pointer to first large page
+ * @param[in]           page_num: page 0-3
+ *//*------------------------------------------------------------------------ */
+int ammu_decode_large_page(unsigned int *p_base_addr, unsigned int page_num) {
+	unsigned int phys_addr, logical_addr, policy_reg, size;
+	int ret;
+
+	printf("*** Decoding Large Page %d  ***\n", page_num);
+
+	// Read CACHE_MMU_LARGE_ADDR_i
+	ret = mem_read((unsigned int)&p_base_addr[page_num], &logical_addr);
+	if (ret != 0) {
+		fprintf(stderr, "internal error (failed to read)!\n");
+		return OMAPCONF_ERR_REG_ACCESS;
+	}
+	printf("CACHE_MMU_LARGE_ADDR_%d = 0x%08X\n", page_num, logical_addr);
+
+	// Read CACHE_MMU_LARGE_XLTE_i
+	ret = mem_read((unsigned int)&p_base_addr[8+page_num], &phys_addr);
+	if (ret != 0) {
+		fprintf(stderr, "internal error (failed to read)!\n");
+		return OMAPCONF_ERR_REG_ACCESS;
+	}
+	printf("CACHE_MMU_LARGE_XLTE_%d = 0x%08X\n", page_num, phys_addr);
+
+	// Read CACHE_MMU_LARGE_POLICY_i
+	ret = mem_read((unsigned int)&p_base_addr[16+page_num], &policy_reg);
+	if (ret != 0) {
+		fprintf(stderr, "internal error (failed to read)!\n");
+		return OMAPCONF_ERR_REG_ACCESS;
+	}
+	printf("CACHE_MMU_LARGE_POLICY_%d = 0x%08X\n", page_num, policy_reg);
+
+	if( (policy_reg&1) == 0 ) {
+		printf("\nPAGE NOT ENABLED\n");
+	} else {
+		printf("\nPAGE ENABLED\n");
+
+		printf("Logical Address  = 0x%08X", logical_addr);
+		if( (policy_reg & 1<<1) == 1<<1 ) {
+			size = 512 * 1024 * 1024; // 512 MB
+		} else {
+			size = 32 * 1024 * 1024; // 32MB
+		}
+		printf(" - 0x%08X\n", (logical_addr+size-1));
+
+		if ( (phys_addr&1) == 1 ) { // "ignore" bit
+			phys_addr = logical_addr;
+		}
+		printf("Physical address = 0x%08X - 0x%08X\n", phys_addr, phys_addr+size-1);
+
+		printf("Policy\n");
+
+		if( (policy_reg & 1<<19) == 1<<19 ) {
+			printf(" * L1 write policy is writeback\n");
+		} else {
+			printf(" * L1 write policy is writethrough\n");
+		}
+
+		if( (policy_reg & 1<<18) == 1<<18 ) {
+			printf(" * L1 allocate policy: follow sideband\n");
+		} else {
+			printf(" * L1 allocate policy: no writes allocated\n");
+		}
+
+		if( (policy_reg & 1<<17) == 1<<17 ) {
+			printf(" * L1 writes posted\n");
+		} else {
+			printf(" * L1 writes non-posted\n");
+		}
+
+		if( (policy_reg & 1<<16) == 1<<16 ) {
+			printf(" * L1 cacheable\n");
+		} else {
+			printf(" * L1 noncacheable\n");
+		}
+
+		if( (policy_reg & 1<<7) == 1<<7 ) {
+			printf(" * Send cache exclusion sideband\n");
+		} else {
+			printf(" * Do not send cache exclusion sideband\n");
+		}
+
+		if( (policy_reg & 1<<6) == 1<<6 ) {
+			printf(" * Preload enabled\n");
+		} else {
+			printf(" * Preload disabled\n");
+		}
+
+		if( (policy_reg & 1<<5) == 1<<5 ) {
+			printf(" * Read-only\n");
+		} else {
+			printf(" * Read/Write\n");
+		}
+
+		if( (policy_reg & 1<<4) == 1<<4 ) {
+			printf(" * Execute-only\n");
+		} else {
+			printf(" * Read/Write/Execute\n");
+		}
+
+		if( (policy_reg & 1<<3) == 1<<3 ) {
+			printf(" * Follow volatile qualifier\n");
+		} else {
+			printf(" * Do not follow volatile qualifier\n");
+		}
+
+		if( (policy_reg & 1<<1) == 1<<1 ) {
+			printf(" * 512 MB page\n");
+		} else {
+			printf(" * 32 MB page\n");
+		}
+	}
+
+	printf("\n");
+
+	return ret;
+}
+
+
+/* ------------------------------------------------------------------------*//**
+ * @FUNCTION            ammu_decode_medium_page
+ * @BRIEF               decodes the parameters for a medium page from the ammu
+ * @RETURNS             0=success, non-zero error
+ * @param[in]           p_base_addr: pointer to first medium page
+ * @param[in]           page_num: page 0-1
+ *//*------------------------------------------------------------------------ */
+int ammu_decode_medium_page(unsigned int *p_base_addr, unsigned int page_num) {
+	unsigned int phys_addr, logical_addr, policy_reg, size;
+	int ret;
+
+	printf("*** Decoding Medium Page %d  ***\n", page_num);
+
+	// Read CACHE_MMU_MEDIUM_ADDR_i
+	ret = mem_read((unsigned int)&p_base_addr[page_num], &logical_addr);
+	if (ret != 0) {
+		fprintf(stderr, "internal error (failed to read)!\n");
+		return OMAPCONF_ERR_REG_ACCESS;
+	}
+	printf("CACHE_MMU_MEDIUM_ADDR_%d = 0x%08X\n", page_num, logical_addr);
+
+	// Read CACHE_MMU_MEDIUM_XLTE_i
+	ret = mem_read((unsigned int)&p_base_addr[16+page_num], &phys_addr);
+	if (ret != 0) {
+		fprintf(stderr, "internal error (failed to read)!\n");
+		return OMAPCONF_ERR_REG_ACCESS;
+	}
+	printf("CACHE_MMU_MEDIUM_XLTE_%d = 0x%08X\n", page_num, phys_addr);
+
+	// Read CACHE_MMU_MEDIUM_POLICY_i
+	ret = mem_read((unsigned int)&p_base_addr[32+page_num], &policy_reg);
+	if (ret != 0) {
+		fprintf(stderr, "internal error (failed to read)!\n");
+		return OMAPCONF_ERR_REG_ACCESS;
+	}
+	printf("CACHE_MMU_MEDIUM_POLICY_%d = 0x%08X\n", page_num, policy_reg);
+
+	if( (policy_reg&1) == 0 ) {
+		printf("\nPAGE NOT ENABLED\n");
+	} else {
+		printf("\nPAGE ENABLED\n");
+
+		printf("Logical Address  = 0x%08X", logical_addr);
+		if( (policy_reg & 1<<1) == 1<<1 ) {
+			size = 256 * 1024; // 256 KB
+		} else {
+			size = 128 * 1024; // 128 KB
+		}
+		printf(" - 0x%08X\n", (logical_addr+size-1));
+
+		if ( (phys_addr&1) == 1 ) { // "ignore" bit
+			phys_addr = logical_addr;
+		}
+		printf("Physical address = 0x%08X - 0x%08X\n", phys_addr, phys_addr+size-1);
+
+		printf("Policy\n");
+
+		if( (policy_reg & 1<<19) == 1<<19 ) {
+			printf(" * L1 write policy is writeback\n");
+		} else {
+			printf(" * L1 write policy is writethrough\n");
+		}
+
+		if( (policy_reg & 1<<18) == 1<<18 ) {
+			printf(" * L1 allocate policy: follow sideband\n");
+		} else {
+			printf(" * L1 allocate policy: no writes allocated\n");
+		}
+
+		if( (policy_reg & 1<<17) == 1<<17 ) {
+			printf(" * L1 writes posted\n");
+		} else {
+			printf(" * L1 writes non-posted\n");
+		}
+
+		if( (policy_reg & 1<<16) == 1<<16 ) {
+			printf(" * L1 cacheable\n");
+		} else {
+			printf(" * L1 noncacheable\n");
+		}
+
+		if( (policy_reg & 1<<7) == 1<<7 ) {
+			printf(" * Send cache exclusion sideband\n");
+		} else {
+			printf(" * Do not send cache exclusion sideband\n");
+		}
+
+		if( (policy_reg & 1<<6) == 1<<6 ) {
+			printf(" * Preload enabled\n");
+		} else {
+			printf(" * Preload disabled\n");
+		}
+
+		if( (policy_reg & 1<<5) == 1<<5 ) {
+			printf(" * Read-only\n");
+		} else {
+			printf(" * Read/Write\n");
+		}
+
+		if( (policy_reg & 1<<4) == 1<<4 ) {
+			printf(" * Execute-only\n");
+		} else {
+			printf(" * Read/Write/Execute\n");
+		}
+
+		if( (policy_reg & 1<<3) == 1<<3 ) {
+			printf(" * Follow volatile qualifier\n");
+		} else {
+			printf(" * Do not follow volatile qualifier\n");
+		}
+
+		if( (policy_reg & 1<<1) == 1<<1 ) {
+			printf(" * 256 KB page\n");
+		} else {
+			printf(" * 128 KB page\n");
+		}
+	}
+
+	printf("\n");
+
+	return ret;
+}
+
+
+/* ------------------------------------------------------------------------*//**
+ * @FUNCTION            ammu_decode_small_page
+ * @BRIEF               decodes the parameters for a small page from the ammu
+ * @RETURNS             0=success, non-zero error
+ * @param[in]           p_base_addr: pointer to first small page
+ * @param[in]           page_num: page 0-9
+ *//*------------------------------------------------------------------------ */
+int ammu_decode_small_page(unsigned int *p_base_addr, unsigned int page_num) {
+	unsigned int phys_addr, logical_addr, policy_reg, size;
+	int ret;
+
+	printf("*** Decoding Small Page %d  ***\n", page_num);
+
+	// Read CACHE_MMU_SMALL_ADDR_i
+	ret = mem_read((unsigned int)&p_base_addr[page_num], &logical_addr);
+	if (ret != 0) {
+		fprintf(stderr, "internal error (failed to read)!\n");
+		return OMAPCONF_ERR_REG_ACCESS;
+	}
+	printf("CACHE_MMU_SMALL_ADDR_%d = 0x%08X\n", page_num, logical_addr);
+
+	// Read CACHE_MMU_SMALL_XLTE_i
+	ret = mem_read((unsigned int)&p_base_addr[32+page_num], &phys_addr);
+	if (ret != 0) {
+		fprintf(stderr, "internal error (failed to read)!\n");
+		return OMAPCONF_ERR_REG_ACCESS;
+	}
+	printf("CACHE_MMU_SMALL_XLTE_%d = 0x%08X\n", page_num, phys_addr);
+
+	// Read CACHE_MMU_SMALL_POLICY_i
+	ret = mem_read((unsigned int)&p_base_addr[64+page_num], &policy_reg);
+	if (ret != 0) {
+		fprintf(stderr, "internal error (failed to read)!\n");
+		return OMAPCONF_ERR_REG_ACCESS;
+	}
+	printf("CACHE_MMU_SMALL_POLICY_%d = 0x%08X\n", page_num, policy_reg);
+
+	if( (policy_reg&1) == 0 ) {
+		printf("\nPAGE NOT ENABLED\n");
+	} else {
+		printf("\nPAGE ENABLED\n");
+
+		printf("Logical Address  = 0x%08X", logical_addr);
+		if( (policy_reg & 1<<1) == 1<<1 ) {
+			size = 16 * 1024; // 16 KB
+		} else {
+			size = 4 * 1024; // 4 KB
+		}
+		printf(" - 0x%08X\n", (logical_addr+size-1));
+
+		if ( (phys_addr&1) == 1 ) { // "ignore" bit
+			phys_addr = logical_addr;
+		}
+		printf("Physical address = 0x%08X - 0x%08X\n", phys_addr, phys_addr+size-1);
+
+		printf("Policy\n");
+
+		if( (policy_reg & 1<<19) == 1<<19 ) {
+			printf(" * L1 write policy is writeback\n");
+		} else {
+			printf(" * L1 write policy is writethrough\n");
+		}
+
+		if( (policy_reg & 1<<18) == 1<<18 ) {
+			printf(" * L1 allocate policy: follow sideband\n");
+		} else {
+			printf(" * L1 allocate policy: no writes allocated\n");
+		}
+
+		if( (policy_reg & 1<<17) == 1<<17 ) {
+			printf(" * L1 writes posted\n");
+		} else {
+			printf(" * L1 writes non-posted\n");
+		}
+
+		if( (policy_reg & 1<<16) == 1<<16 ) {
+			printf(" * L1 cacheable\n");
+		} else {
+			printf(" * L1 noncacheable\n");
+		}
+
+		if( (policy_reg & 1<<7) == 1<<7 ) {
+			printf(" * Send cache exclusion sideband\n");
+		} else {
+			printf(" * Do not send cache exclusion sideband\n");
+		}
+
+		if( (policy_reg & 1<<6) == 1<<6 ) {
+			printf(" * Preload enabled\n");
+		} else {
+			printf(" * Preload disabled\n");
+		}
+
+		if( (policy_reg & 1<<5) == 1<<5 ) {
+			printf(" * Read-only\n");
+		} else {
+			printf(" * Read/Write\n");
+		}
+
+		if( (policy_reg & 1<<4) == 1<<4 ) {
+			printf(" * Execute-only\n");
+		} else {
+			printf(" * Read/Write/Execute\n");
+		}
+
+		if( (policy_reg & 1<<3) == 1<<3 ) {
+			printf(" * Follow volatile qualifier\n");
+		} else {
+			printf(" * Do not follow volatile qualifier\n");
+		}
+
+		if( (policy_reg & 1<<1) == 1<<1 ) {
+			printf(" * 16 KB page\n");
+		} else {
+			printf(" * 4 KB page\n");
+		}
+	}
+
+	printf("\n");
+
+	return ret;
+}

--- a/arch/arm/mach-omap/common/ammu.h
+++ b/arch/arm/mach-omap/common/ammu.h
@@ -1,14 +1,14 @@
 /*
  *
- * @Component			OMAPCONF
- * @Filename			help.h
- * @Description			Help Library for OMAPCONF
- * @Author			Patrick Titiano (p-titiano@ti.com)
- * @Date			2006
- * @Copyright			Texas Instruments Incorporated
+ * @Component                   OMAPCONF
+ * @Filename                    ammu.h
+ * @Description                 Functions Related to Parsing AMMU
+ * @Author                      Brad Griffis (bgriffis@ti.com)
+ * @Date                        2017
+ * @Copyright                   Texas Instruments Incorporated
  *
  *
- * Copyright (C) 2006 Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (C) 2017 Texas Instruments Incorporated - http://www.ti.com/
  *
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -41,57 +41,11 @@
  *
  */
 
+#ifndef __AMMU_H__
+#define __AMMU_H__
 
-#ifndef __OMAPCONF_HELP_H__
-#define __OMAPCONF_HELP_H__
-
-
-typedef enum {
-	HELP_RW,
-	HELP_I2C_RW,
-	HELP_SOC_PWST,
-	HELP_SOC_OPP,
-	HELP_VOLT,
-	HELP_DPLL,
-	HELP_PRCM,
-	HELP_SR,
-	HELP_MPUSS,
-	HELP_EMIF,
-	HELP_WKDEP,
-	HELP_AVS,
-	HELP_ABB,
-	HELP_HWOBS,
-	HELP_TEMPERATURE,
-	HELP_HWTEMPERATURE,
-	HELP_AUDIT,
-	HELP_TRACE,
-	HELP_COUNTERS,
-	HELP_FORCEDETECT,
-	HELP_AUDIOIC,
-	HELP_DISPLAY,
-	HELP_CAMERA,
-	HELP_STATDEP,
-	HELP_PMIC,
-	HELP_ABE,
-	HELP_EXPORT,
-	HELP_CTRLMOD,
-	HELP_TIMERS_32K,
-	HELP_MCASP,
-	HELP_CROSSBAR,
-	HELP_ALL,
-	HELP_USAGE,
-	HELP_AMMU,
-	HELP_CATEGORY_MAX,
-} help_category;
-
-
-int err_arg_too_many_msg_show(help_category cat);
-int err_arg_missing_msg_show(help_category cat);
-int err_arg_msg_show(help_category cat);
-int err_internal_msg_show(void);
-int err_unknown_argument_msg_show(char *s);
-
-void help(help_category cat);
-
+int ammu_decode_large_page(unsigned int *p_base_addr, unsigned int page_num);
+int ammu_decode_medium_page(unsigned int *p_base_addr, unsigned int page_num);
+int ammu_decode_small_page(unsigned int *p_base_addr, unsigned int page_num);
 
 #endif

--- a/arch/arm/mach-omap/dra7/ammu_dra7xx.c
+++ b/arch/arm/mach-omap/dra7/ammu_dra7xx.c
@@ -1,0 +1,145 @@
+/*
+ *
+ * @Component                   OMAPCONF
+ * @Filename                    ammu_dra7xx.c
+ * @Description                 Functions Related to Parsing AMMU
+ * @Author                      Brad Griffis (bgriffis@ti.com)
+ * @Date                        2017
+ * @Copyright                   Texas Instruments Incorporated
+ *
+ *
+ * Copyright (C) 2017 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *    Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ *    Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the
+ *    distribution.
+ *
+ *    Neither the name of Texas Instruments Incorporated nor the names of
+ *    its contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <ammu.h>
+#include <mem.h>
+#include <lib.h>
+
+#define CHECK_RET(x) if(x != 0) return x
+#define CM_IPU1_IPU1_CLKCTRL 0x4A005520u
+#define CM_IPU2_IPU2_CLKCTRL 0x4A008920u
+
+/* ------------------------------------------------------------------------*//**
+ * @FUNCTION            dra7xx_ammu_decode
+ * @BRIEF               Decodes all the AMMU page mappings
+ * @RETURNS             0=success, non-zero error
+ * @param[in]           ipu: Can be "all", "ipu1", or "ipu2"
+ *//*------------------------------------------------------------------------ */
+int dra7xx_ammu_decode(const char *ipu)
+{
+	unsigned int unicache_addr, ipu_clkctrl;
+	int ret;
+
+	if (strcmp(ipu, "all") == 0 ) {
+		ret = dra7xx_ammu_decode("ipu1");
+		CHECK_RET(ret);
+		ret = dra7xx_ammu_decode("ipu2");
+		CHECK_RET(ret);
+	}
+
+	if (strcmp(ipu, "ipu1") == 0 ) {
+		ret = mem_read(CM_IPU1_IPU1_CLKCTRL, &ipu_clkctrl);
+		CHECK_RET(ret);
+		if ( (ipu_clkctrl&3) == 0 ) {
+			fprintf(stderr, "Cannot read from IPU1 while "
+				"CM_IPU1_IPU1_CLKCTRL[1:0] = 0!\n");
+			fprintf(stderr, "Linux users may try:\n"
+				"echo on > "
+				"/sys/bus/platform/devices/58820000.ipu/power/control\n");
+			return OMAPCONF_ERR_REG_ACCESS;
+		}
+		unicache_addr = 0x58880800;
+		printf("**************************************************\n");
+		printf("******   Decoding AMMU Mappings for IPU1    ******\n");
+		printf("**************************************************\n\n");
+	}
+
+	if (strcmp(ipu, "ipu2") == 0 ) {
+		ret = mem_read(CM_IPU2_IPU2_CLKCTRL, &ipu_clkctrl);
+		CHECK_RET(ret);
+		if ( (ipu_clkctrl&3) == 0 ) {
+			fprintf(stderr, "Cannot read from IPU2 while "
+				"CM_IPU2_IPU2_CLKCTRL[1:0] = 0!\n");
+			fprintf(stderr, "Linux users may try:\n"
+				"echo on > "
+				"/sys/bus/platform/devices/55020000.ipu/power/control\n");
+			return OMAPCONF_ERR_REG_ACCESS;
+		}
+		unicache_addr = 0x55080800;
+		printf("**************************************************\n");
+		printf("******   Decoding AMMU Mappings for IPU2    ******\n");
+		printf("**************************************************\n\n");
+	}
+
+	// DRA7xx AMMUs contain 4 large pages
+	ret = ammu_decode_large_page((unsigned int *)unicache_addr, 0u);
+	CHECK_RET(ret);
+	ret = ammu_decode_large_page((unsigned int *)unicache_addr, 1u);
+	CHECK_RET(ret);
+	ret = ammu_decode_large_page((unsigned int *)unicache_addr, 2u);
+	CHECK_RET(ret);
+	ret = ammu_decode_large_page((unsigned int *)unicache_addr, 3u);
+	CHECK_RET(ret);
+
+	// DRA7xx AMMUs contain 2 medium pages
+	ret = ammu_decode_medium_page((unsigned int *)(unicache_addr+0x60), 0u);
+	CHECK_RET(ret);
+	ret = ammu_decode_medium_page((unsigned int *)(unicache_addr+0x60), 1u);
+	CHECK_RET(ret);
+
+	// DRA7xx AMMUs contain 10 small pages
+	ret = ammu_decode_small_page((unsigned int *)(unicache_addr+0x120), 0u);
+	CHECK_RET(ret);
+	ret = ammu_decode_small_page((unsigned int *)(unicache_addr+0x120), 1u);
+	CHECK_RET(ret);
+	ret = ammu_decode_small_page((unsigned int *)(unicache_addr+0x120), 2u);
+	CHECK_RET(ret);
+	ret = ammu_decode_small_page((unsigned int *)(unicache_addr+0x120), 3u);
+	CHECK_RET(ret);
+	ret = ammu_decode_small_page((unsigned int *)(unicache_addr+0x120), 4u);
+	CHECK_RET(ret);
+	ret = ammu_decode_small_page((unsigned int *)(unicache_addr+0x120), 5u);
+	CHECK_RET(ret);
+	ret = ammu_decode_small_page((unsigned int *)(unicache_addr+0x120), 6u);
+	CHECK_RET(ret);
+	ret = ammu_decode_small_page((unsigned int *)(unicache_addr+0x120), 7u);
+	CHECK_RET(ret);
+	ret = ammu_decode_small_page((unsigned int *)(unicache_addr+0x120), 8u);
+	CHECK_RET(ret);
+	ret = ammu_decode_small_page((unsigned int *)(unicache_addr+0x120), 9u);
+	CHECK_RET(ret);
+
+	return ret;
+}

--- a/arch/arm/mach-omap/dra7/ammu_dra7xx.h
+++ b/arch/arm/mach-omap/dra7/ammu_dra7xx.h
@@ -1,14 +1,14 @@
 /*
  *
- * @Component			OMAPCONF
- * @Filename			help.h
- * @Description			Help Library for OMAPCONF
- * @Author			Patrick Titiano (p-titiano@ti.com)
- * @Date			2006
- * @Copyright			Texas Instruments Incorporated
+ * @Component                   OMAPCONF
+ * @Filename                    ammu_dra7xx.h
+ * @Description                 Functions Related to Parsing AMMU
+ * @Author                      Brad Griffis (bgriffis@ti.com)
+ * @Date                        2017
+ * @Copyright                   Texas Instruments Incorporated
  *
  *
- * Copyright (C) 2006 Texas Instruments Incorporated - http://www.ti.com/
+ * Copyright (C) 2017 Texas Instruments Incorporated - http://www.ti.com/
  *
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -41,57 +41,9 @@
  *
  */
 
+#ifndef __AMMU_DRA7XX_H__
+#define __AMMU_DRA7XX_H__
 
-#ifndef __OMAPCONF_HELP_H__
-#define __OMAPCONF_HELP_H__
-
-
-typedef enum {
-	HELP_RW,
-	HELP_I2C_RW,
-	HELP_SOC_PWST,
-	HELP_SOC_OPP,
-	HELP_VOLT,
-	HELP_DPLL,
-	HELP_PRCM,
-	HELP_SR,
-	HELP_MPUSS,
-	HELP_EMIF,
-	HELP_WKDEP,
-	HELP_AVS,
-	HELP_ABB,
-	HELP_HWOBS,
-	HELP_TEMPERATURE,
-	HELP_HWTEMPERATURE,
-	HELP_AUDIT,
-	HELP_TRACE,
-	HELP_COUNTERS,
-	HELP_FORCEDETECT,
-	HELP_AUDIOIC,
-	HELP_DISPLAY,
-	HELP_CAMERA,
-	HELP_STATDEP,
-	HELP_PMIC,
-	HELP_ABE,
-	HELP_EXPORT,
-	HELP_CTRLMOD,
-	HELP_TIMERS_32K,
-	HELP_MCASP,
-	HELP_CROSSBAR,
-	HELP_ALL,
-	HELP_USAGE,
-	HELP_AMMU,
-	HELP_CATEGORY_MAX,
-} help_category;
-
-
-int err_arg_too_many_msg_show(help_category cat);
-int err_arg_missing_msg_show(help_category cat);
-int err_arg_msg_show(help_category cat);
-int err_internal_msg_show(void);
-int err_unknown_argument_msg_show(char *s);
-
-void help(help_category cat);
-
+int dra7xx_ammu_decode(const char *ipu);
 
 #endif

--- a/arch/arm/mach-omap/dra7/help_dra7xx.c
+++ b/arch/arm/mach-omap/dra7/help_dra7xx.c
@@ -172,6 +172,14 @@ void help_dra7xx(help_category cat, char *context)
 			"domains), including main modules frequencies.\n");
 	}
 
+	if ((cat == HELP_ALL) || (cat == HELP_AMMU)) {
+		printf("\n\tomapconf show ammu [<instance>]\n");
+		printf("\t    Show AMMU mappings for <instance>.\n");
+		printf("\t    Supported <instance>: ipu1, ipu2, all.\n");
+		printf("\t    If <instance> is omitted or <instance> = all, all\n");
+		printf("\t    ipu ammu mappings will be shown.\n");
+	}
+
 	if ((cat == HELP_ALL) || (cat == HELP_TRACE)) {
 		printf("\n\tomapconf trace perf setup [<cfgfile>]\n");
 		printf(

--- a/arch/arm/mach-omap/dra7/main_dra7xx.c
+++ b/arch/arm/mach-omap/dra7/main_dra7xx.c
@@ -63,6 +63,7 @@
 #include <crossbar.h>
 #include <abb7xx.h>
 #include <statcoll/sci_swcapture_dra.h>
+#include <ammu_dra7xx.h>
 
 
 /* #define MAIN_DRA7XX_DEBUG */
@@ -258,6 +259,21 @@ int main_dra7xx_show(int argc, char *argv[])
 			return abb7xx_config_show(stdout);
 		else
 			return err_arg_too_many_msg_show(HELP_ABB);
+	} else if (strcmp(argv[0], "ammu") == 0) {
+		if (argc == 1) {
+			return dra7xx_ammu_decode("all");
+		} else if (argc == 2) {
+			if (strcmp(argv[1], "all") == 0)
+				return dra7xx_ammu_decode(argv[1]);
+			else if (strcmp(argv[1], "ipu1") == 0)
+				return dra7xx_ammu_decode(argv[1]);
+			else if (strcmp(argv[1], "ipu2") == 0)
+				return dra7xx_ammu_decode(argv[1]);
+			else
+				return err_arg_msg_show(HELP_AMMU);
+		} else {
+			return err_arg_too_many_msg_show(HELP_AMMU);
+                }
 	} else {
 		return err_unknown_argument_msg_show(argv[0]);
 	}


### PR DESCRIPTION
This patch set adds commands such as:

omapconf show ammu ipu1
omapconf show ammu ipu2
omapconf show ammu all

This quickly decodes the AMMU page tables so you can understand the mappings easily.